### PR TITLE
Fix neo4j node ids

### DIFF
--- a/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jConfiguration.java
+++ b/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jConfiguration.java
@@ -16,6 +16,7 @@
 package nl.tudelft.graphalytics.neo4j;
 
 import org.neo4j.graphdb.DynamicRelationshipType;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 
 /**
@@ -27,6 +28,10 @@ public final class Neo4jConfiguration {
 
 	public static final RelationshipType EDGE = DynamicRelationshipType.withName("EDGE");
 	public static final String ID_PROPERTY = "VID";
+
+	public enum VertexLabelEnum implements Label {
+		VERTEX
+	}
 
 	/** Class contains only static values, so no instance required. */
 	private Neo4jConfiguration() { }

--- a/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jDatabaseImporter.java
+++ b/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jDatabaseImporter.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2015 Delft University of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.tudelft.graphalytics.neo4j;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.EDGE;
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.ID_PROPERTY;
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.VertexLabelEnum.VERTEX;
+
+/**
+ * Utility class for importing datasets into a new Neo4j database.
+ *
+ * @author Tim Hegeman
+ */
+public class Neo4jDatabaseImporter implements AutoCloseable {
+
+	private final GraphDatabaseService database;
+	private Transaction openTransaction;
+	private int operationsInOpenTransaction;
+	private final int maxOperationsPerTransactions;
+
+	/**
+	 * @param database                     the underlying Neo4j database to insert nodes and relationships into
+	 * @param maxOperationsPerTransactions the maximum number of operations in a transaction before committing
+	 */
+	public Neo4jDatabaseImporter(GraphDatabaseService database, int maxOperationsPerTransactions) {
+		this.database = database;
+		this.openTransaction = null;
+		this.operationsInOpenTransaction = 0;
+		this.maxOperationsPerTransactions = maxOperationsPerTransactions;
+	}
+
+	/**
+	 * Retrieves a Neo4j node with the given vertexId, or creates and returns a new node if it did not exist.
+	 *
+	 * @param vertexId the id of the vertex to find or create a Neo4j node for
+	 * @return the matching Neo4j node
+	 */
+	public Node createOrGetNode(long vertexId) {
+		ensureInTransaction();
+
+		return createOrGetNodeInTransaction(vertexId);
+	}
+
+	/**
+	 * Creates a new (directed) edge between a pair of nodes identified by vertex ids. Both the source and destination
+	 * nodes are created if they do not exist.
+	 *
+	 * @param sourceVertexId      the id of the source vertex of the edge
+	 * @param destinationVertexId the id of the destination vertex of the edge
+	 */
+	public void createEdge(long sourceVertexId, long destinationVertexId) {
+		ensureInTransaction();
+
+		Node source = createOrGetNodeInTransaction(sourceVertexId);
+		Node destination = createOrGetNodeInTransaction(destinationVertexId);
+		source.createRelationshipTo(destination, EDGE);
+	}
+
+	/**
+	 * Retrieves a Neo4j node with the given vertexId, or creates and returns a new node if it did not exist. Assumes
+	 * a transactions is active.
+	 *
+	 * @param vertexId the id of the vertex to find or create a Neo4j node for
+	 * @return the matching Neo4j node
+	 */
+	private Node createOrGetNodeInTransaction(long vertexId) {
+		Node node = findNode(vertexId);
+		if (node == null) {
+			node = database.createNode(VERTEX);
+			node.setProperty(ID_PROPERTY, vertexId);
+		}
+		return node;
+	}
+
+	/**
+	 * @param vertexId the id of the vertex to find a Neo4j node for
+	 * @return the matching Neo4j node if it exists, null otherwise
+	 */
+	private Node findNode(long vertexId) {
+		Node node = null;
+		for (Node match : database.findNodesByLabelAndProperty(VERTEX, ID_PROPERTY, vertexId)) {
+			node = match;
+		}
+		return node;
+	}
+
+	/**
+	 * Ensures that a transaction is active which has not yet reached its maximum number of operations. If no
+	 * transaction is active, it begins a new transaction. If a transaction is active and the maximum number of
+	 * operations has been reached, the active transaction is finalized and a new transaction is started. Finally, the
+	 * number of operations in the (new) active transaction is incremented.
+	 */
+	private void ensureInTransaction() {
+		if (openTransaction == null) {
+			openTransaction = database.beginTx();
+		} else if (operationsInOpenTransaction >= maxOperationsPerTransactions) {
+			finalizeTransaction();
+			openTransaction = database.beginTx();
+			operationsInOpenTransaction = 0;
+		}
+
+		operationsInOpenTransaction++;
+	}
+
+	/**
+	 * Finalizes the active Neo4j transaction.
+	 */
+	private void finalizeTransaction() {
+		openTransaction.success();
+		openTransaction.close();
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (openTransaction != null) {
+			finalizeTransaction();
+			openTransaction = null;
+		}
+	}
+}

--- a/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jPlatform.java
+++ b/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/Neo4jPlatform.java
@@ -40,6 +40,7 @@ import java.nio.file.Paths;
 import java.util.*;
 
 import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.EDGE;
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.VertexLabelEnum.VERTEX;
 
 /**
  * Entry point of the Graphalytics benchmark for Neo4j. Provides the platform
@@ -120,9 +121,9 @@ public class Neo4jPlatform implements Platform {
 
 			// Insert the nodes if needed
 			if (!inserter.nodeExists(sourceId))
-				inserter.createNode(sourceId, createPropertyMap(sourceId));
+				inserter.createNode(sourceId, createPropertyMap(sourceId), VERTEX);
 			if (!inserter.nodeExists(destinationId))
-				inserter.createNode(destinationId, createPropertyMap(destinationId));
+				inserter.createNode(destinationId, createPropertyMap(destinationId), VERTEX);
 
 			// Create the edge
 			inserter.createRelationship(sourceId, destinationId, EDGE, EMPTY);
@@ -144,7 +145,7 @@ public class Neo4jPlatform implements Platform {
 			// Read the source vertex and create a node if needed
 			long sourceId = lineTokens.nextLong();
 			if (!inserter.nodeExists(sourceId))
-				inserter.createNode(sourceId, createPropertyMap(sourceId));
+				inserter.createNode(sourceId, createPropertyMap(sourceId), VERTEX);
 
 			// Read any number of destination IDs
 			while (lineTokens.hasNext()) {
@@ -152,7 +153,7 @@ public class Neo4jPlatform implements Platform {
 
 				// Insert the node if needed
 				if (!inserter.nodeExists(destinationId))
-					inserter.createNode(destinationId, createPropertyMap(destinationId));
+					inserter.createNode(destinationId, createPropertyMap(destinationId), VERTEX);
 
 				// Create the edge
 				inserter.createRelationship(sourceId, destinationId, EDGE, EMPTY);

--- a/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/bfs/BreadthFirstSearchComputation.java
+++ b/platforms/neo4j/src/main/java/nl/tudelft/graphalytics/neo4j/bfs/BreadthFirstSearchComputation.java
@@ -21,6 +21,9 @@ import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.graphdb.traversal.Traverser;
 
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.ID_PROPERTY;
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.VertexLabelEnum.VERTEX;
+
 /**
  * Implementation of the breadth-first search algorithm in Neo4j. This class is responsible for the computation of the
  * distance to each node from the start node, given a functional Neo4j database instance.
@@ -49,7 +52,11 @@ public class BreadthFirstSearchComputation {
 	 */
 	public void run() {
 		try (Transaction transaction = graphDatabase.beginTx()) {
-			Node startNode = graphDatabase.getNodeById(startVertexId);
+			Node startNode = null;
+			for (Node matchingNode : graphDatabase.findNodesByLabelAndProperty(VERTEX, ID_PROPERTY, startVertexId)) {
+				startNode = matchingNode;
+			}
+
 			TraversalDescription traversalDescription = graphDatabase.traversalDescription()
 					.breadthFirst()
 					.relationships(Neo4jConfiguration.EDGE, Direction.OUTGOING)

--- a/platforms/neo4j/src/test/java/nl/tudelft/graphalytics/neo4j/AbstractComputationTest.java
+++ b/platforms/neo4j/src/test/java/nl/tudelft/graphalytics/neo4j/AbstractComputationTest.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.*;
 
+import static nl.tudelft.graphalytics.neo4j.Neo4jConfiguration.VertexLabelEnum.VERTEX;
+
 /**
  * Base class for testing Neo4j jobs. This class is responsible for creating and cleaning up test databases, doing
  * transaction management, etc.
@@ -63,6 +65,7 @@ public abstract class AbstractComputationTest {
 			vertexToNodeIds = new HashMap<>();
 			for (long vertexId : vertices) {
 				Node newNode = graphDatabase.createNode();
+				newNode.addLabel(VERTEX);
 				newNode.setProperty(Neo4jConfiguration.ID_PROPERTY, vertexId);
 				nodes.put(vertexId, newNode);
 				vertexToNodeIds.put(vertexId, newNode.getId());

--- a/platforms/neo4j/src/test/java/nl/tudelft/graphalytics/neo4j/bfs/BreadthFirstSearchComputationTest.java
+++ b/platforms/neo4j/src/test/java/nl/tudelft/graphalytics/neo4j/bfs/BreadthFirstSearchComputationTest.java
@@ -42,7 +42,7 @@ public class BreadthFirstSearchComputationTest extends AbstractComputationTest {
 		// Load data
 		loadGraphFromResource("/test-examples/bfs-input");
 		// Execute algorithm
-		new BreadthFirstSearchComputation(graphDatabase, getNodeId(BFS_START_NODE)).run();
+		new BreadthFirstSearchComputation(graphDatabase, BFS_START_NODE).run();
 		// Verify output
 		Map<Long, Long> expectedOutput = parseOutputResource("/test-examples/bfs-output");
 		try (Transaction transaction = graphDatabase.beginTx()) {


### PR DESCRIPTION
Phased out any and all dependencies on Neo4j node ids. This should fix the errors that occurred when importing datasets with large vertex ids.

Note: I did not try the LDBC dataset specifically, but I have tried a small example graph with a bunch of vertices with ids up to and including `Long.MAX_VALUE`.