### PR TITLE
Add configuration option to request platforms to write their output to a file for validation

### DIFF
--- a/config-template/runs/all.properties
+++ b/config-template/runs/all.properties
@@ -10,3 +10,6 @@ benchmark.run.graphs =
 # Select a subset of the algorithms (leave blank to select all)
 benchmark.run.algorithms = 
 
+# Specify if the output should be stored and where
+benchmark.run.output-required = true
+benchmark.run.output-directory = ./output/

--- a/config-template/runs/example.properties
+++ b/config-template/runs/example.properties
@@ -10,3 +10,6 @@ benchmark.run.graphs = graph-1, graph-2
 # Select a subset of the algorithms (leave blank to select all)
 benchmark.run.algorithms = evo, bfs
 
+# Specify if the output should be stored and where
+benchmark.run.output-required = true
+benchmark.run.output-directory = ./output/

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/BenchmarkSuiteRunner.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/BenchmarkSuiteRunner.java
@@ -25,6 +25,10 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * Helper class for executing all benchmarks in a BenchmarkSuite on a specific Platform.
  *
@@ -72,7 +76,17 @@ public class BenchmarkSuiteRunner {
 
 			// Execute all benchmarks for this graph
 			for (Benchmark benchmark : benchmarkSuite.getBenchmarksForGraph(graph)) {
-				LOG.info("");
+				// Ensure that the output directory exists, if needed
+				if (benchmark.isOutputRequired()) {
+					try {
+						Files.createDirectories(Paths.get(benchmark.getOutputPath()).getParent());
+					} catch (IOException e) {
+						LOG.error("Failed to create output directory \"" +
+								Paths.get(benchmark.getOutputPath()).getParent() + "\", skipping.", e);
+						continue;
+					}
+				}
+
 				// Use a BenchmarkResultBuilder to create the BenchmarkResult for this Benchmark
 				BenchmarkResultBuilder benchmarkResultBuilder = new BenchmarkResultBuilder(benchmark);
 
@@ -108,7 +122,6 @@ public class BenchmarkSuiteRunner {
 				benchmarkSuiteResultBuilder.withBenchmarkResult(benchmarkResult);
 				// Execute the post-benchmark steps of all plugins
 				plugins.postBenchmark(benchmark, benchmarkResult);
-				LOG.info("");
 			}
 
 			// Delete the graph

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/domain/Benchmark.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/domain/Benchmark.java
@@ -28,16 +28,23 @@ public final class Benchmark implements Serializable {
 	private final Algorithm algorithm;
 	private final Graph graph;
 	private final Object algorithmParameters;
+	private final boolean outputRequired;
+	private final String outputPath;
 
 	/**
 	 * @param algorithm           the algorithm to run for this benchmark
 	 * @param graph               the graph to run the algorithm on
 	 * @param algorithmParameters parameters for the algorithm
+	 * @param outputRequired      true iff the output of the algorithm should be written to (a) file(s)
+	 * @param outputPath          the path to write the output to, or the prefix if multiple output files are required
 	 */
-	public Benchmark(Algorithm algorithm, Graph graph, Object algorithmParameters) {
+	public Benchmark(Algorithm algorithm, Graph graph, Object algorithmParameters, boolean outputRequired,
+			String outputPath) {
 		this.algorithm = algorithm;
 		this.graph = graph;
 		this.algorithmParameters = algorithmParameters;
+		this.outputRequired = outputRequired;
+		this.outputPath = outputPath;
 	}
 
 	/**
@@ -59,6 +66,20 @@ public final class Benchmark implements Serializable {
 	 */
 	public Object getAlgorithmParameters() {
 		return algorithmParameters;
+	}
+
+	/**
+	 * @return true iff the output of the algorithm should be written to (a) file(s)
+	 */
+	public boolean isOutputRequired() {
+		return outputRequired;
+	}
+
+	/**
+	 * @return the path to write the output to, or the prefix if multiple output files are required
+	 */
+	public String getOutputPath() {
+		return outputPath;
 	}
 
 	/**

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/domain/Graph.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/domain/Graph.java
@@ -34,8 +34,8 @@ public final class Graph implements Serializable {
 
 	/**
 	 * @param name             the unique name of the graph
-	 * @param vertexFilePath   the path of the vertex data file, relative to the graph root directory
-	 * @param edgeFilePath     the path of the edge data file, relative to the graph root directory
+	 * @param vertexFilePath   the path of the vertex data file
+	 * @param edgeFilePath     the path of the edge data file
 	 * @param graphFormat      the format of the graph
 	 * @param numberOfVertices the number of vertices in the graph
 	 * @param numberOfEdges    the number of edges in the graph
@@ -58,14 +58,14 @@ public final class Graph implements Serializable {
 	}
 
 	/**
-	 * @return the path of the vertex data file, relative to the graph root directory
+	 * @return the path of the vertex data file
 	 */
 	public String getVertexFilePath() {
 		return vertexFilePath;
 	}
 
 	/**
-	 * @return the path of the edge data file, relative to the graph root directory
+	 * @return the path of the edge data file
 	 */
 	public String getEdgeFilePath() {
 		return edgeFilePath;


### PR DESCRIPTION
This PR includes additions to the "run" configuration for storing algorithm output on disk. This option will be useful when benchmarks are run on larger datasets so we can check the output of platforms for correctness.

The API change is limited to two additional methods in the Benchmark class. Existing platform implementations will ignore the option, but will still function.