### PR TITLE
Made toPropertyGraph in GraphStructure public to make it usable by other platforms

### DIFF
--- a/graphalytics-validation/src/main/java/nl/tudelft/graphalytics/validation/GraphStructure.java
+++ b/graphalytics-validation/src/main/java/nl/tudelft/graphalytics/validation/GraphStructure.java
@@ -57,7 +57,7 @@ public final class GraphStructure {
 	 *
 	 * @return a PropertyGraph representation of the same graph
 	 */
-	PropertyGraph<Void, Void> toPropertyGraph() {
+	public PropertyGraph<Void, Void> toPropertyGraph() {
 		PropertyGraph<Void, Void> graph = new PropertyGraph<>();
 		// Copy vertices
 		for (long vertexId : edgeLists.keySet()) {


### PR DESCRIPTION
Method toPropertyGraph of GraphStructure had no access modifier, made it public to permit access from the graphalytic platforms.