### PR TITLE
Fixed bug in EquivalenceValidationRule and improved EpsilonValidationRule

### DIFF
--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/VertexValidator.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/VertexValidator.java
@@ -61,15 +61,13 @@ public class VertexValidator<E> {
 		try {
 			validationResults = parseFile(validationFile);
 		} catch (IOException e) {
-			LOG.warn("Failed to read validation file '" + validationFile + "'");
-			return false;
+			throw new ValidatorException("Failed to read validation file '" + validationFile + "'");
 		}
 
 		try {
 			outputResults = parseFile(outputFile);
 		} catch (IOException e) {
-			LOG.warn("Failed to read output file '" + outputFile + "'");
-			return false;
+			throw new ValidatorException("Failed to read output file '" + outputFile + "'");
 		}
 
 		ArrayList<Long> keys = new ArrayList<Long>();
@@ -108,7 +106,7 @@ public class VertexValidator<E> {
 				error = "Vertex " + id + " is not a valid vertex";
 			} else if (!rule.match(outputValue, correctValue)) {
 				incorrectVertices++;
-				error = "Vertex " + id + " has value '" + outputValue + "', but it should be '" + correctValue + "'";
+				error = "Vertex " + id + " has value '" + outputValue + "', but valid value is '" + correctValue + "'";
 			} else {
 				correctVertices++;
 			}
@@ -164,7 +162,7 @@ public class VertexValidator<E> {
 					long vertexId = Long.parseLong(parts[0]);
 					E vertexValue = rule.parse(parts.length > 1 ? parts[1] : "");
 					results.put(vertexId,  vertexValue);
-				} catch(NumberFormatException e) {
+				} catch(Throwable e) {
 					LOG.warn("Skipping invalid line '" + line + "' of file '" + file + "'");
 				}
 			}

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/EpsilonValidationRule.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/EpsilonValidationRule.java
@@ -21,35 +21,70 @@ package nl.tudelft.graphalytics.validation.rule;
  */
 public class EpsilonValidationRule implements ValidationRule<Double> {
 
+	// The platform output should be within this margin of the reference output (i.e., |a-b|/b < threshold)
 	private final static double COMPARISON_THRESHOLD = 0.0001;
 
+	// Maximum value for when a double is considered to be zero-like (10 ULPs away from 0.0)
+	private final static double MAX_NEAR_ZERO = Double.MIN_VALUE * 10;
+
+	// Minimum value for when a double is considered to be infinity-like (within 1% of MAX_VALUE)
+	private final static double MIN_NEAR_INFINITY = Double.MAX_VALUE * 0.999;
+
+
 	@Override
-	public Double parse(String val) {
-		try {
-			return Double.parseDouble(val);
-		} catch(NumberFormatException e) {
-			return null;
+	public Double parse(String val) throws NumberFormatException {
+
+		// According to the specifications for Java SE7, Double.parseDouble(String) will
+		// only consider the string "Infinity" (optionally prefixed with "+" or "-") to
+		// be a infinity value. Graphalytics will be more liberal in what is accepted.
+		String low = val.toLowerCase();
+
+		if (low.equals("inf") || low.equals("+inf") || low.equals("infinity") || low.equals("+infinity")) {
+			return Double.POSITIVE_INFINITY;
+		} else if (low.equals("-inf") || low.equals("-infinity")) {
+			return Double.NEGATIVE_INFINITY;
 		}
+
+		return Double.parseDouble(val);
+	}
+
+	private static boolean isNearInfinity(double v) {
+		return Double.isInfinite(v) || Math.abs(v) > MIN_NEAR_INFINITY;
+	}
+
+	private static boolean isNearZero(double v) {
+		return Math.abs(v) < MAX_NEAR_ZERO;
 	}
 
 	@Override
 	public boolean match(Double outputValue, Double correctValue) {
-		try {
-			double a = outputValue;
-			double b = correctValue;
 
-			if (a == b) {
-				return true;
-			} else if (Double.isNaN(a) && Double.isNaN(b)) {
-				return true;
-			} else if (Math.abs(a - b) < COMPARISON_THRESHOLD * b) {
-				return true;
-			} else {
-				return false;
-			}
+		double a = outputValue;
+		double b = correctValue;
 
-		} catch(NumberFormatException e) {
-			return false;
+		// Check if a and b are identical
+		if (a == b && a == b + 1) {
+			return true;
+		}
+
+		// Check if a and b are both NaN
+		else if (Double.isNaN(a) && Double.isNaN(b)) {
+			return true;
+		}
+
+		// Check if a and b are both infinity-like
+		else if (isNearInfinity(a) && isNearInfinity(b)) {
+			return Math.signum(a) == Math.signum(b); //Signs match?
+		}
+
+		// Check if a and b are both zero-like
+		else if (isNearZero(a) && isNearZero(b)) {
+			return true;
+		}
+
+		// Use Graphalytics rule: |a-b|/b < THRESHOLD
+		else {
+			return Math.abs(a - b) < COMPARISON_THRESHOLD * b;
 		}
 	}
 }

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/EquivalenceValidationRule.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/EquivalenceValidationRule.java
@@ -22,33 +22,32 @@ import java.util.Map;
  * Validation rule which checks if vertex values are identical under equivalence.
  */
 public class EquivalenceValidationRule implements ValidationRule<Long> {
-	private Map<Long, Long> left2right;
-	private Map<Long, Long> right2left;
+	private Map<Long, Long> leftMap;
+	private Map<Long, Long> rightMap;
+	private long counter;
 
 	public EquivalenceValidationRule() {
-		left2right = new HashMap<Long, Long>();
-		right2left = new HashMap<Long, Long>();
+		leftMap = new HashMap<Long, Long>();
+		rightMap = new HashMap<Long, Long>();
+		counter = 0;
 	}
 
 	@Override
-	public Long parse(String val) {
-		try {
-			return Long.parseLong(val);
-		} catch(NumberFormatException e) {
-			return null;
-		}
+	public Long parse(String val) throws NumberFormatException {
+		return Long.parseLong(val);
 	}
 
 	@Override
 	public boolean match(Long left, Long right) {
-		Long a = left2right.get(left);
-		Long b = right2left.get(right);
+		Long a = leftMap.get(left);
+		Long b = rightMap.get(right);
 
 		// If a and b are both null then we have not seen these labels
-		// before. Add the labels to the equivalence maps.
+		// before. Unify the labels by mapping them to the same value.
 		if (a == null && b == null) {
-			left2right.put(left, right);
-			right2left.put(right, left);
+			leftMap.put(left, counter);
+			rightMap.put(right, counter);
+			counter++;
 			return true;
 		}
 

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/MatchLongValidationRule.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/MatchLongValidationRule.java
@@ -21,12 +21,8 @@ package nl.tudelft.graphalytics.validation.rule;
 public class MatchLongValidationRule implements ValidationRule<Long> {
 
 	@Override
-	public Long parse(String val) {
-		try {
-			return Long.parseLong(val);
-		} catch(NumberFormatException e) {
-			return null;
-		}
+	public Long parse(String val) throws NumberFormatException {
+		return Long.parseLong(val);
 	}
 
 	@Override

--- a/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/ValidationRule.java
+++ b/graphalytics-core/src/main/java/nl/tudelft/graphalytics/validation/rule/ValidationRule.java
@@ -25,6 +25,6 @@ package nl.tudelft.graphalytics.validation.rule;
  * @param <E> Type of the vertex value.
  */
 public interface ValidationRule<E> {
-	public E parse(String val);
+	public E parse(String val) throws Throwable;
 	public boolean match(E lhs, E rhs);
 }


### PR DESCRIPTION
There was a bug in EquivalenceValidationRule, it has been fixed.

Additionally, many of the validations were failing because the EpsilonValidationRule is too strict. Some improvements have been made to make the comparison between floating-point values more liberal:
- Both the strings "inf" and "infinity" (case is ignored, optionally prefixed with "+" or "-") are now considered to be Infinity.  
- Any value very close to Double.MAX_VALUE (at most 0.1% off) is considered to be infinity
- Any value very close to 0.0 (at most 10 UPLs off) is considered to be zero.